### PR TITLE
Correct >>> DEMO <<< website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple & light weight (2kb minified & zipped) vanilla javascript plugin to create beautiful animations when you scrolllll! Harness the power of the most intuitive interaction and make your websites come alive!
 
-[>>> DEMO <<<](https://alexfox.dev/lax/)
+[>>> DEMO <<<](https://alexfox.dev/laxxx/)
 
 
 ## Getting started


### PR DESCRIPTION
I wanted to open the Demo and it did not work. So I checked the commits and saw the changes from `laxxx` to `lax`.

This PR changes back the website linked to https://alexfox.dev/laxxx/ instead of  https://alexfox.dev/lax/.

Or is the new url in progress?
