### PR TITLE
lax.addElement o.transforms is a array?

### DIFF
--- a/src/lax.js
+++ b/src/lax.js
@@ -163,7 +163,7 @@
     lax.addElement = function(el) {
       var o = {
         el: el,
-        transforms: []
+        transforms: {}
       }
 
       var presetNames = el.attributes["data-lax-preset"] && el.attributes["data-lax-preset"].value


### PR DESCRIPTION
Hi, man, I have some doubts in method of addElement, why o.transforms is a array?
I think {} more suitable.when I debugging, I find o.transforms is a array but take responsibility of object.
So I think o.transforms is a {}, trouble you to answer my doubts, thanks.