### PR TITLE
fix "this" bugs

### DIFF
--- a/src/lax.js
+++ b/src/lax.js
@@ -154,9 +154,9 @@
     }
 
     lax.removeElement = function(el) {
-      const i = this.elements.findIndex(o => o.el = el)
+      const i = lax.elements.findIndex(o => o.el = el)
       if(i > -1) {
-        this.elements.splice(i, 1)
+        lax.elements.splice(i, 1)
       }
     }
 
@@ -237,7 +237,7 @@
       var selector = Object.keys(transforms).map(t => `[${t}]`).join(",")
       selector += ",[data-lax-preset]"
 
-      document.querySelectorAll(selector).forEach(this.addElement)
+      document.querySelectorAll(selector).forEach(lax.addElement)
     }
 
     lax.updateElement = function(o) {


### PR DESCRIPTION
Hello, I found a small bug when using lax.js, when I need to remove the element node.
```
const removeEl = lax.removeElement
removeEl(el) // Cannot read property 'findIndex' of undefined
```
I think it should be a problem with "this", you can change it to lax to avoid the problem, and then find the same problem in "populateElements".
I thought it might be that you were negligent, or I didn't understand your intentions. I hope you can solve it to me, thank you.