### PR TITLE
docs: Add use-lax to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ To increase performance lax.js indexes the list of elements to animate when the 
 
 See below for working examples:
 * [react](https://codepen.io/alexfoxy/pen/PLaKaE)
+* [react (using hooks)](https://github.com/arthurdenner/use-lax)
 * [vue](https://codepen.io/alexfoxy/pen/ZPRZBq)
 
 You can also call `lax.removeElement(domElement)` when the component unmounts.


### PR DESCRIPTION
Hi! :wave: 

I found out your library yesterday and found it pretty interesting.

Following your [React example](https://codepen.io/alexfoxy/pen/PLaKaE), I created a library to abstract its use with hooks, [use-lax](https://github.com/arthurdenner/use-lax).

This PR just adds a link to my library in the README file.