### PR TITLE
Add EmberJS reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ window.onload = function() {
 
 4) Scroll and enjoy!
 
-### Usage With React, Vue.js & DOM Changes
-To increase performance lax.js indexes the list of elements to animate when the page loads. If you're using a library like React or vue.js, it is likely that you are adding elements after the initial `window.onload`. Because of this you will need to call `lax.addElement(domElement)` when you add components to the DOM that you want to animate. 
+### Usage With React, Vue.js, EmberJS & DOM Changes
+To increase performance lax.js indexes the list of elements to animate when the page loads. If you're using a library like React, vue.js or EmberJS, it is likely that you are adding elements after the initial `window.onload`. Because of this you will need to call `lax.addElement(domElement)` when you add components to the DOM that you want to animate. 
 
 See below for working examples:
 * [react](https://codepen.io/alexfoxy/pen/PLaKaE)
 * [react (using hooks)](https://github.com/arthurdenner/use-lax)
 * [vue](https://codepen.io/alexfoxy/pen/ZPRZBq)
+* [ember](https://github.com/redpencilio/ember-lax)
 
 You can also call `lax.removeElement(domElement)` when the component unmounts.
 


### PR DESCRIPTION
Your library sparked much interest.  Great work! 💪  It's super nice to use!

Following your React example, we made an implementation for EmberJS at [ember-lax](https://github.com/redpencilio/ember-lax).  It supports use by a component (a wrapping tag indicating useage of Lax) and by an element modifier (automatically triggering lax for a single element) based on the readme.

Can we add a reference to the readme?