### PR TITLE
Mobile First, Function instead of eval and fixed paths in the dev/ folder.

### DIFF
--- a/dev/inertia.html
+++ b/dev/inertia.html
@@ -61,7 +61,7 @@
 <body>
   <div id="main">
     <div id="header" class="section">
-      <img src="./img/a.png" id="letter" data-lax-translate-x="0 0, 1000 1000" />
+      <img src="../docs/img/a.png" id="letter" data-lax-translate-x="0 0, 1000 1000" />
     </div>
 
   </div>

--- a/dev/reactive.html
+++ b/dev/reactive.html
@@ -77,7 +77,7 @@
 <body>
   <div id="main">
     <div id="header" class="section">
-      <img src="./img/a.png" 
+      <img src="../docs/img/a.png" 
         class="lax"
         data-lax-scale="0 1, vh 5"
         data-lax-scale_s="0 1, vh 1"

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -97,7 +97,13 @@
     window.onload = function() {
       document.getElementById("main").classList.add("loaded")
 
-      lax.setup()
+      lax.setup({
+        breakpoints: {
+          small: 400,
+          medium: 800,
+          large: 1200
+        }
+      })
 
       const update = () => {
         lax.update(window.scrollY)
@@ -105,6 +111,8 @@
       }
 
       window.requestAnimationFrame(update)
+
+      window.addEventListener("resize", () => lax.updateElements())
     }
   </script>
 
@@ -120,6 +128,7 @@
         data-lax-rotate= "0 -20, 900 20, 2000 -20 | loop=2000 offset=200"
         data-lax-translate-x= "0 110, 800 -100, 900 -110, 1900 100, 2000 110 | loop=2000 offset=200"
         data-lax-translate-y= "0 -elh, (vh*10) (vh+elh) | loop=(vh*10) offset=1000 speed=1"
+        data-lax-scale_small= "(vh*4) 1, 0 0"
       ></div>
 
       <div 
@@ -128,6 +137,7 @@
         data-lax-rotate= "0 -20, 900 20, 2000 -20 | loop=2000 offset=500 speed=1.5"
         data-lax-translate-x= "0 110, 800 -100, 900 -110, 1900 100, 2000 110 | loop=2000 offset=500 speed=1.5"
         data-lax-translate-y= "0 -elh, (vh*10) (vh+elh) | loop=(vh*10) offset=1000 speed=1"
+        data-lax-scale_medium= "(vh*4) 1, 0 0"
       ></div>
 
       <div 
@@ -136,6 +146,7 @@
         data-lax-rotate= "0 -20, 900 20, 2000 -20 | loop=2000 offset=1000"
         data-lax-translate-x= "0 110, 800 -100, 900 -110, 1900 100, 2000 110 | loop=2000 offset=1000"
         data-lax-translate-y= "0 -elh, (vh*10) (vh+elh) | loop=(vh*10) offset=400 speed=1"
+        data-lax-scale_large= "(vh*4) 1, 0 0"
       ></div>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lax.js",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"scripts": {
 		"build": "babel src -d lib; uglifyjs lib/lax.js -o lib/lax.min.js -c -m; gzip < lib/lax.min.js > lib/lax.min.js.gz;"
 	},

--- a/src/lax.js
+++ b/src/lax.js
@@ -160,6 +160,7 @@
 
     lax.setup = (o={}) => {
       lax.breakpoints = o.breakpoints || {}
+      lax.breakpointsKeys = Object.keys(lax.breakpoints)
       
       lax.selector = o.selector || '.lax'
       lax.populateElements()
@@ -350,7 +351,11 @@
       }
 
       for(let i in transforms) {
-        const transformData = transforms[i][currentBreakpoint] || transforms[i]["default"]
+        let transformData
+        for (let j = lax.breakpointsKeys.indexOf(currentBreakpoint); j >= 0 && !transformData; j--) {
+          transformData = transforms[i][lax.breakpointsKeys[j]]
+        }
+        transformData =  transformData || transforms[i]["default"]
 
         if(!transformData) {
           // console.log(`lax error: there is no setting for key ${i} and screen size ${currentBreakpoint}. Try adding a default value!`)

--- a/src/lax.js
+++ b/src/lax.js
@@ -154,7 +154,7 @@
     }
 
     function fnOrVal(s) {
-      if(s[0] === "(") return eval(s)
+      if(s[0] === "(") return Function(`'use strict'; return (${s})`)()
       else return parseFloat(s)
     }
 

--- a/src/lax.js
+++ b/src/lax.js
@@ -251,7 +251,7 @@
           if(a.name === "data-lax-anchor") {
             o["data-lax-anchor"] = a.value === "self" ? el : document.querySelector(a.value)
             const rect = o["data-lax-anchor"].getBoundingClientRect()
-            o.anchorTop = Math.floor(rect.top) + window.scrollY
+            o.anchorTop = Math.floor(rect.top) + (window.scrollY || window.pageYOffset)
           } else {
             const tString = a.value
               .replace(/vw/g, window.innerWidth)


### PR DESCRIPTION
Hi, nice job. We included this library in our project.

I made the breakpoints "mobile first" like Bootstrap, Foundation and all main responsive frameworks. I find it easier to understand and we don't have to duplify the values when using multiple breakpoints. I added a test to docs/demo.html

Before:
![imagen](https://user-images.githubusercontent.com/1145371/79861853-61c82200-83d5-11ea-876f-de92c8ca8e06.png)

After:
![imagen](https://user-images.githubusercontent.com/1145371/79862017-aa7fdb00-83d5-11ea-89b2-de2dad573de9.png)

Function and eval are both not safe but Function is much faster than eval. Maybe we should find a better alternative like using global functions or a custom data-* syntax.

Please feel free to modify my pull request.