### PR TITLE
Allow raw DOM element to be passed to `addElements`

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ lax.addElements(
 
 ### Element options
 
+#### `elements: Array of DOM nodes`
+
+Pass references to raw DOM elements to allow for more flexible selection patterns.
+In this case, a unique `selector` must still be passed as the first argument, however it does _not_ need to be a valid DOM selector.
+This allows the library to tag the elements for removal later. Example:
+
+```js
+[$('.selector')[0]]
+```
+
 #### `style: StyleObject`
 
 Add static CSS to each element, for example:

--- a/README.md
+++ b/README.md
@@ -167,16 +167,6 @@ lax.addElements(
 
 ### Element options
 
-#### `elements: Array of DOM nodes`
-
-Pass references to raw DOM elements to allow for more flexible selection patterns.
-In this case, a unique `selector` must still be passed as the first argument, however it does _not_ need to be a valid DOM selector.
-This allows the library to tag the elements for removal later. Example:
-
-```js
-[$('.selector')[0]]
-```
-
 #### `style: StyleObject`
 
 Add static CSS to each element, for example:
@@ -184,6 +174,20 @@ Add static CSS to each element, for example:
 ```css
 {
   transform: '200ms scale ease-in-out';
+}
+```
+
+#### `elements: Array<DOM nodes>`
+
+Pass references to raw DOM elements to allow for more flexible selection patterns. In this case, a unique `selector` must still be passed as the first argument, however it does _not_ need to be a valid DOM selector.
+
+This allows the library to tag the elements for removal later. Example:
+
+```js
+const myDomElements = $('.selector')
+
+{
+  elements: myDomElements
 }
 ```
 

--- a/src/lax.js
+++ b/src/lax.js
@@ -582,7 +582,7 @@
       }
 
       addElements = (selector, transforms, options) => {
-        const domElements = document.querySelectorAll(selector)
+        const domElements = options.domElements || document.querySelectorAll(selector)
 
         domElements.forEach((domElement, i) => {
           this.elements.push(new LaxElement(selector, this, domElement, transforms, i, options))


### PR DESCRIPTION
Allows more flexible selection patterns.

See https://github.com/alexfoxy/lax.js/issues/158