### PR TITLE
Use correct API for determining screen dimensions

### DIFF
--- a/src/lax.js
+++ b/src/lax.js
@@ -503,19 +503,19 @@
         this.findAndAddElements()
 
         window.requestAnimationFrame(this.onAnimationFrame)
-        this.windowWidth = document.body.clientWidth
-        this.windowHeight = document.body.clientHeight
+        this.windowWidth = window.visualViewport.width
+        this.windowHeight = window.visualViewport.height
 
         window.onresize = this.onWindowResize
       }
 
       onWindowResize = () => {
-        const changed = document.body.clientWidth !== this.windowWidth ||
-          document.body.clientHeight !== this.windowHeight
+        const changed = window.visualViewport.width !== this.windowWidth ||
+          window.visualViewport.height !== this.windowHeight
 
         if (changed) {
-          this.windowWidth = document.body.clientWidth
-          this.windowHeight = document.body.clientHeight
+          this.windowWidth = window.visualViewport.width
+          this.windowHeight = window.visualViewport.height
           this.elements.forEach(el => el.calculateTransforms())
         }
       }


### PR DESCRIPTION
`visualViewport` is widely supported and I believe it is the preferred method for determining logical `screenHeight`. `clientWidth` and `clientHeight` do not I believe take zoom into account and also `clientHeight` is on iOS devices just the height of the page (so it never changes)

Separately, I believe the `window.onresize` API is also insufficient for our purposes as this event is not guaranteed to fire at 60fps whenever `visualViewport` changes. My solution is to listen for changes directly: (I am only concerned about height changes for my purposes):

```js
var set_height = function() {
  var current_height = window.visualViewport.height
  var lax_height = lax.windowHeight
  
  if (current_height != lax_height) {
    lax.onWindowResize()
  }
  
  requestAnimationFrame(set_height)
}

requestAnimationFrame(set_height)
```

Curious for your thoughts!