### PR TITLE
[BUGFIX] Continue to allow empty options to be passed to `addElements`

### DIFF
--- a/src/lax.js
+++ b/src/lax.js
@@ -585,7 +585,7 @@
         })
       }
 
-      addElements = (selector, transforms, options) => {
+      addElements = (selector, transforms, options = {}) => {
         const domElements = options.domElements || document.querySelectorAll(selector)
 
         domElements.forEach((domElement, i) => {


### PR DESCRIPTION
Addresses https://github.com/alexfoxy/lax.js/pull/159#issuecomment-948477244.

Thanks for catching this before a release, @RogerPodacter!