### PR TITLE
Fix blurOur type in preset explorer

### DIFF
--- a/docs/preset-explorer.html
+++ b/docs/preset-explorer.html
@@ -138,7 +138,7 @@
         flipX: [...baseSettings.spin],
         flipY: [...baseSettings.spin],
         blurIn: [...baseSettings.blur],
-        blurOur: [...baseSettings.blur],
+        blurOut: [...baseSettings.blur],
         blurInOut: [...baseSettings.blur],
       }
 


### PR DESCRIPTION
This blurOur typo prevents the explorer from working correctly when testing that option.